### PR TITLE
Implement basic navigation layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,14 @@ There should also be a section in which the user can write how much they spend y
 
 This project should be built for the web, so only web technologies should be used. Prefer a clean approach with vanilla JS (no React, no Angular, etc.).
 For now, we can just use localstorage to store data
+
+## Layout
+
+The application is organized in four main sections that can be reached via a sidebar on desktop screens or through a bottom tab bar on mobile devices.
+
+1. **Forecast** – Displays the main graph along with a summary table.
+2. **Assets** – Shows total wealth, individual assets and an "Add Asset" button.
+3. **Flows** – Lists the defined flows and an "Add Flow" button.
+4. **Expenses** – Allows editing of the yearly expense value.
+
+The sidebar is hidden on small screens while the bottom navigation becomes visible, providing a mobile friendly, iOS-style experience.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Cast</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<div id="app">
+  <nav id="sidebar">
+    <button data-section="forecast">Forecast</button>
+    <button data-section="assets">Assets</button>
+    <button data-section="flows">Flows</button>
+    <button data-section="expenses">Expenses</button>
+  </nav>
+  <main id="content">
+    <section id="forecast" class="section active">
+      <h1>Forecast</h1>
+      <div class="graph-placeholder">Graph Placeholder</div>
+      <table class="table-placeholder">
+        <tr><th>Year</th><th>Value</th></tr>
+        <tr><td>2024</td><td>$10,000</td></tr>
+      </table>
+    </section>
+    <section id="assets" class="section">
+      <h1>Assets</h1>
+      <div class="assets-placeholder">Assets list here</div>
+      <button class="add-asset">Add Asset</button>
+    </section>
+    <section id="flows" class="section">
+      <h1>Flows</h1>
+      <div class="flows-placeholder">Flows list here</div>
+      <button class="add-flow">Add Flow</button>
+    </section>
+    <section id="expenses" class="section">
+      <h1>Expenses</h1>
+      <label>
+        Yearly Expenses:
+        <input type="number" id="yearly-expenses" />
+      </label>
+    </section>
+  </main>
+</div>
+<div id="mobile-tabs">
+  <button data-section="forecast">Forecast</button>
+  <button data-section="assets">Assets</button>
+  <button data-section="flows">Flows</button>
+  <button data-section="expenses">Expenses</button>
+</div>
+<script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,12 @@
+const sections = document.querySelectorAll('.section');
+const navButtons = document.querySelectorAll('#sidebar button, #mobile-tabs button');
+
+navButtons.forEach(btn => {
+  btn.addEventListener('click', () => {
+    const target = btn.getAttribute('data-section');
+    sections.forEach(sec => {
+      if (sec.id === target) sec.classList.add('active');
+      else sec.classList.remove('active');
+    });
+  });
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,49 @@
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+}
+#app {
+  display: flex;
+  min-height: 100vh;
+}
+#sidebar {
+  display: flex;
+  flex-direction: column;
+  background: #f0f0f0;
+  padding: 1rem;
+}
+#sidebar button {
+  margin: 0.5rem 0;
+}
+#content {
+  flex: 1;
+  padding: 1rem;
+}
+.section {
+  display: none;
+}
+.section.active {
+  display: block;
+}
+#mobile-tabs {
+  display: none;
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: #f0f0f0;
+  display: flex;
+  justify-content: space-around;
+  padding: 0.5rem 0;
+}
+#mobile-tabs button {
+  flex: 1;
+}
+@media (max-width: 600px) {
+  #sidebar {
+    display: none;
+  }
+  #mobile-tabs {
+    display: flex;
+  }
+}


### PR DESCRIPTION
## Summary
- build layout for Forecast, Assets, Flows and Expenses sections
- show sidebar on desktop and tab navigation on mobile
- implement simple section switching script
- document layout in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6884ba76df508330924f257efea84dc0