### PR TITLE
Implement sidebar and mobile tab navigation

### DIFF
--- a/app.js
+++ b/app.js
@@ -43,6 +43,25 @@ const saveFlow = document.getElementById('save-flow');
 const cancelFlow = document.getElementById('cancel-flow');
 const deleteFlowBtn = document.getElementById('delete-flow');
 
+const navButtons = document.querySelectorAll('.nav-btn');
+const sections = {
+    forecast: document.getElementById('forecast-section'),
+    assets: document.getElementById('assets-section'),
+    flows: document.getElementById('flows-section'),
+    expenses: document.getElementById('expenses-section')
+};
+
+function showSection(name){
+    Object.keys(sections).forEach(key=>{
+        sections[key].classList.toggle('hidden', key!==name);
+        document.querySelector(`[data-section="${key}"]`).classList.toggle('active', key===name);
+    });
+}
+
+navButtons.forEach(btn=>{
+    btn.addEventListener('click', ()=>showSection(btn.dataset.section));
+});
+
 let editIndex = null;
 let editFlowIndex = null;
 
@@ -373,3 +392,4 @@ function updateChart() {
 
 renderAssets();
 updateChart();
+showSection('forecast');

--- a/index.html
+++ b/index.html
@@ -9,30 +9,43 @@
 </head>
 <body>
     <h1>Cast</h1>
-    <div class="container">
-        <div class="left">
-            <canvas id="chart"></canvas>
-            <label id="years-wrap">Years to display
-                <input type="number" id="years" value="20" min="1">
-            </label>
-            <div id="retirement">
-                <span id="retire-best"></span>
-                <span id="retire-avg"></span>
-                <span id="retire-worst"></span>
-            </div>
-            <table id="year-table"></table>
-        </div>
-        <div class="right">
-            <h2>Assets</h2>
-            <div id="total-wealth"></div>
-            <div id="asset-list"></div>
-            <button id="add-asset">Add Asset</button>
-            <h2>Flows</h2>
-            <div id="flow-list"></div>
-            <button id="add-flow">Add Flow</button>
-            <h2>Yearly Expenses</h2>
-            <input type="number" id="expenses" placeholder="Yearly expenses" />
-        </div>
+    <div class="app-container">
+        <nav id="sidebar">
+            <button class="nav-btn active" data-section="forecast">Forecast</button>
+            <button class="nav-btn" data-section="assets">Assets</button>
+            <button class="nav-btn" data-section="flows">Flows</button>
+            <button class="nav-btn" data-section="expenses">Expenses</button>
+        </nav>
+        <main id="content">
+            <section id="forecast-section" class="section">
+                <canvas id="chart"></canvas>
+                <label id="years-wrap">Years to display
+                    <input type="number" id="years" value="20" min="1">
+                </label>
+                <div id="retirement">
+                    <span id="retire-best"></span>
+                    <span id="retire-avg"></span>
+                    <span id="retire-worst"></span>
+                </div>
+                <table id="year-table"></table>
+            </section>
+            <section id="assets-section" class="section hidden">
+                <h2>Assets</h2>
+                <div id="total-wealth"></div>
+                <div id="asset-list"></div>
+                <button id="add-asset">Add Asset</button>
+            </section>
+            <section id="flows-section" class="section hidden">
+                <h2>Flows</h2>
+                <div id="flow-list"></div>
+                <button id="add-flow">Add Flow</button>
+            </section>
+            <section id="expenses-section" class="section hidden">
+                <h2>Yearly Expenses</h2>
+                <input type="number" id="expenses" placeholder="Yearly expenses" />
+            </section>
+        </main>
+    </div>
     <div id="asset-form" class="modal hidden">
         <div class="modal-content">
             <h3 id="form-title">New Asset</h3>

--- a/style.css
+++ b/style.css
@@ -129,3 +129,55 @@ label {
     gap: 0.25rem;
 }
 
+/* Layout for new navigation */
+.app-container {
+    display: flex;
+    min-height: 100vh;
+}
+
+#sidebar {
+    background: white;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    display: flex;
+    flex-direction: column;
+}
+
+#sidebar button {
+    border: none;
+    background: none;
+    padding: 1rem;
+    text-align: left;
+}
+
+#sidebar button.active {
+    font-weight: bold;
+}
+
+#content {
+    flex: 1;
+    padding: 1rem;
+}
+
+.section.hidden {
+    display: none;
+}
+
+@media (max-width: 600px) {
+    #sidebar {
+        flex-direction: row;
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        border-top: 1px solid #ccc;
+        z-index: 10;
+    }
+    #sidebar button {
+        flex: 1;
+        text-align: center;
+    }
+    #content {
+        padding-bottom: 4rem;
+    }
+}
+


### PR DESCRIPTION
## Summary
- create sidebar & tabbed navigation
- move main content into sections for Forecast, Assets, Flows and Expenses
- update CSS for responsive layout
- add JS helpers to switch between sections

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6884bbc6b8788330ada548b3a58a5f8d