### PR TITLE
Add asset distribution pie chart

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
         <div class="right">
             <h2>Assets</h2>
             <div id="total-wealth"></div>
+            <canvas id="asset-pie"></canvas>
             <div id="asset-list"></div>
             <button id="add-asset">Add Asset</button>
             <h2>Flows</h2>

--- a/style.css
+++ b/style.css
@@ -75,6 +75,20 @@ body {
     border-radius: 4px;
 }
 
+.asset-color {
+    width: 12px;
+    height: 12px;
+    display: inline-block;
+    margin-right: 0.5rem;
+    vertical-align: middle;
+    border-radius: 2px;
+}
+
+#asset-pie {
+    max-width: 100%;
+    max-height: 200px;
+}
+
 .modal {
     position: fixed;
     top: 0;


### PR DESCRIPTION
## Summary
- add pie chart placeholder to the asset panel
- color-code assets and show color boxes
- generate pie chart showing asset distribution

## Testing
- `node -c app.js`

------
https://chatgpt.com/codex/tasks/task_e_6884ed36c7a88330b54f76c7b18688bc