### PR TITLE
Improve asset modal usability and cleanup

### DIFF
--- a/app.js
+++ b/app.js
@@ -37,12 +37,16 @@ const incAvg = document.getElementById('inc-avg');
 const incWorst = document.getElementById('inc-worst');
 const incType = document.getElementById('inc-type');
 const compoundInput = document.getElementById('asset-compound');
-const weightInput = document.getElementById('asset-weight');
 const compToggle = document.getElementById('asset-comp-toggle');
 const assetAddFlowBtn = document.getElementById('asset-add-flow');
+const assetFlowList = document.getElementById('asset-flow-list');
+const compFreqLabel = document.getElementById('compound-frequency');
 const saveAsset = document.getElementById('save-asset');
 const cancelAsset = document.getElementById('cancel-asset');
 const deleteAssetBtn = document.getElementById('delete-asset');
+
+compToggle.onchange = updateCompoundVisibility;
+updateCompoundVisibility();
 
 const flowList = document.getElementById('flow-list');
 const addFlowBtn = document.getElementById('add-flow');
@@ -111,7 +115,7 @@ function renderAssets() {
 
         assetList.appendChild(div);
     });
-    const total = assets.reduce((s,a)=>s+a.value*(a.weight??100)/100,0);
+    const total = assets.reduce((s,a)=>s+a.value,0);
     totalWealthDiv.textContent = `Total wealth: ${formatNumber(total)}`;
     renderFlows();
     updatePieChart();
@@ -132,6 +136,26 @@ function renderFlows() {
     updateSankey();
 }
 
+function renderAssetFlows(index){
+    assetFlowList.innerHTML = '';
+    if(index==null) return;
+    flows.forEach((flow,i)=>{
+        if(flow.from===index || flow.to===index){
+            const div = document.createElement('div');
+            div.className = 'asset';
+            const from = flow.from>=0 ? (assets[flow.from]?.name||'') : OUTSIDE_NAME;
+            const to = flow.to>=0 ? (assets[flow.to]?.name||'') : OUTSIDE_NAME;
+            div.textContent = `${from} -> ${to}: ${flow.amount}`;
+            div.onclick = () => openFlowForm(i);
+            assetFlowList.appendChild(div);
+        }
+    });
+}
+
+function updateCompoundVisibility(){
+    compFreqLabel.style.display = compToggle.checked ? 'flex' : 'none';
+}
+
 function openForm(index) {
     if (index != null) {
         editIndex = index;
@@ -145,10 +169,11 @@ function openForm(index) {
         incWorst.value = a.incWorst;
         incType.value = a.incType || 'abs';
         compoundInput.value = a.compound;
-        weightInput.value = a.weight ?? 100;
         compToggle.checked = a.compoundEnabled !== false;
+        updateCompoundVisibility();
         deleteAssetBtn.classList.remove('hidden');
         assetAddFlowBtn.classList.remove('hidden');
+        renderAssetFlows(index);
     } else {
         editIndex = null;
         formTitle.textContent = 'New Asset';
@@ -160,10 +185,11 @@ function openForm(index) {
         incWorst.value = '';
         incType.value = 'abs';
         compoundInput.value = 'monthly';
-        weightInput.value = 100;
         compToggle.checked = true;
+        updateCompoundVisibility();
         deleteAssetBtn.classList.add('hidden');
-        assetAddFlowBtn.classList.add('hidden');
+        assetAddFlowBtn.classList.remove('hidden');
+        renderAssetFlows(null);
     }
     formModal.classList.remove('hidden');
 }
@@ -181,7 +207,6 @@ function formData() {
         incWorst: parseFloat(incWorst.value) || 0,
         incType: incType.value,
         compound: compoundInput.value,
-        weight: parseFloat(weightInput.value) || 100,
         compoundEnabled: compToggle.checked,
     };
 }
@@ -313,7 +338,7 @@ function forecast(months) {
     const wVals = assets.map(a => a.value);
     const startVals = assets.map(a => a.value);
 
-    best[0] = assets.reduce((s,a)=>s+a.value*(a.weight??100)/100,0);
+    best[0] = assets.reduce((s,a)=>s+a.value,0);
     avg[0] = best[0];
     worst[0] = best[0];
 
@@ -357,9 +382,9 @@ function forecast(months) {
                 wVals[f.to]+=f.amount;
             }
         });
-        best[i] = bVals.reduce((s,v,idx)=>s+v*(assets[idx].weight??100)/100,0);
-        avg[i] = aVals.reduce((s,v,idx)=>s+v*(assets[idx].weight??100)/100,0);
-        worst[i] = wVals.reduce((s,v,idx)=>s+v*(assets[idx].weight??100)/100,0);
+        best[i] = bVals.reduce((s,v)=>s+v,0);
+        avg[i] = aVals.reduce((s,v)=>s+v,0);
+        worst[i] = wVals.reduce((s,v)=>s+v,0);
     }
     return {best, avg, worst};
 }
@@ -496,7 +521,7 @@ function updateChart() {
 
 function updatePieChart(){
     const labels = assets.map(a=>a.name);
-    const data = assets.map(a=>a.value*(a.weight??100)/100);
+    const data = assets.map(a=>a.value);
     const colors = assets.map((a,i)=>{
         if(!a.color) a.color = colorPalette[i % colorPalette.length];
         return a.color;

--- a/index.html
+++ b/index.html
@@ -64,7 +64,6 @@
                 </select>
             </label>
             <label>Starting Value <input type="number" id="asset-value"></label>
-            <label>Portfolio Weight (%) <input type="number" id="asset-weight" value="100" min="0" max="100"></label>
             <label>Increase Type
                 <select id="inc-type">
                     <option value="abs">Absolute (monthly)</option>
@@ -85,22 +84,28 @@
                     <input type="number" id="inc-worst" placeholder="Worst">
                 </label>
             </div>
-            <button id="asset-add-flow" type="button">Add Flow from this Asset</button>
-            <label class="toggle-switch">
-                <input type="checkbox" id="asset-comp-toggle" checked>
-                <span class="toggle-slider"></span>
+            <div id="asset-flow-list" class="asset-flow-list"></div>
+            <button id="asset-add-flow" type="button"><i class="fa fa-plus"></i> Add Flow</button>
+            <div class="toggle-row">
                 <span class="toggle-label">Enable Compounding</span>
-            </label>
-            <label>Compounding Frequency
+                <label class="toggle-switch">
+                    <input type="checkbox" id="asset-comp-toggle" checked>
+                    <span class="toggle-slider"></span>
+                </label>
+            </div>
+            <label id="compound-frequency">
+                Compounding Frequency
                 <select id="asset-compound">
                     <option value="monthly">Monthly</option>
                     <option value="yearly">Yearly</option>
                 </select>
             </label>
 
-            <button id="delete-asset" class="danger hidden">Delete</button>
-            <button id="save-asset">Save</button>
-            <button id="cancel-asset">Cancel</button>
+            <div class="modal-actions">
+                <button id="delete-asset" class="danger hidden"><i class="fa fa-trash"></i></button>
+                <button id="save-asset"><i class="fa fa-check"></i> Save</button>
+                <button id="cancel-asset"><i class="fa fa-times"></i> Cancel</button>
+            </div>
         </div>
     </div>
 <div id="flow-form" class="modal hidden">
@@ -113,9 +118,11 @@
             <select id="flow-to"></select>
         </label>
         <label>Amount per month <input type="number" id="flow-amount"></label>
-        <button id="delete-flow" class="danger hidden">Delete</button>
-        <button id="save-flow">Save</button>
-        <button id="cancel-flow">Cancel</button>
+        <div class="modal-actions">
+            <button id="delete-flow" class="danger hidden"><i class="fa fa-trash"></i></button>
+            <button id="save-flow"><i class="fa fa-check"></i> Save</button>
+            <button id="cancel-flow"><i class="fa fa-times"></i> Cancel</button>
+        </div>
     </div>
 </div>
     <script src="app.js"></script>

--- a/style.css
+++ b/style.css
@@ -154,18 +154,27 @@ body {
 
 .modal {
     position: fixed;
-    top: 60px;
-    bottom: 60px;
+    top: 0;
+    bottom: 0;
     left: 0;
     right: 0;
     background: rgba(0,0,0,0.4);
     display: flex;
     justify-content: center;
-    align-items: flex-start;
+    align-items: center;
     backdrop-filter: blur(4px);
     transition: opacity 0.3s ease;
     overflow-y: auto;
     padding: 1rem;
+}
+
+@media (max-width: 768px) {
+    .modal {
+        top: 60px;
+        bottom: 60px;
+        align-items: flex-start;
+        padding-bottom: calc(60px + 1rem);
+    }
 }
 
 .modal-content {
@@ -173,7 +182,6 @@ body {
     padding: 1.5rem;
     width: 100%;
     max-width: 400px;
-    max-height: 100%;
     overflow-y: auto;
     border-radius: 20px;
     box-shadow: 0 20px 25px -5px rgba(0,0,0,0.1), 0 10px 10px -5px rgba(0,0,0,0.04);

--- a/style.css
+++ b/style.css
@@ -86,13 +86,14 @@ body {
     margin-bottom: 0.75rem;
 }
 
-#asset-list, #flow-list {
+#asset-list, #flow-list, .asset-flow-list {
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
 }
 
-#flow-list {
+#flow-list,
+.asset-flow-list {
     margin-top: 1rem;
 }
 
@@ -153,23 +154,27 @@ body {
 
 .modal {
     position: fixed;
-    top: 0;
+    top: 60px;
+    bottom: 60px;
     left: 0;
     right: 0;
-    bottom: 0;
     background: rgba(0,0,0,0.4);
     display: flex;
     justify-content: center;
-    align-items: center;
+    align-items: flex-start;
     backdrop-filter: blur(4px);
     transition: opacity 0.3s ease;
-    overflow: scroll;
+    overflow-y: auto;
+    padding: 1rem;
 }
 
 .modal-content {
     background: white;
-    padding: 2rem;
-    width: 400px;
+    padding: 1.5rem;
+    width: 100%;
+    max-width: 400px;
+    max-height: 100%;
+    overflow-y: auto;
     border-radius: 20px;
     box-shadow: 0 20px 25px -5px rgba(0,0,0,0.1), 0 10px 10px -5px rgba(0,0,0,0.04);
     display: flex;
@@ -338,6 +343,7 @@ select {
 /* Toggle switch styling */
 .toggle-switch {
     display: flex;
+    flex-direction: row;
     align-items: center;
     gap: 0.75rem;
     cursor: pointer;
@@ -382,6 +388,12 @@ select {
     font-weight: 500;
     color: #475569;
     font-size: 0.9375rem;
+}
+
+.toggle-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
 }
 
 /* Modal actions styling */


### PR DESCRIPTION
## Summary
- make modals fit between title and tab bars and scroll on mobile
- show flows of the asset inside asset form modal
- hide compounding frequency when disabled and align switch/label
- remove portfolio weight feature
- add icons to modal action buttons

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6886701a0cf483309072f60ccf6230bb