### PR TITLE
Add per-asset inflation settings

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,6 +140,17 @@
                     <option value="yearly">Yearly</option>
                 </select>
             </label>
+            <div class="toggle-row">
+                <span class="toggle-label">Subject to inflation?</span>
+                <label class="toggle-switch">
+                    <input type="checkbox" id="asset-inflation-toggle">
+                    <span class="toggle-slider"></span>
+                </label>
+            </div>
+            <label id="inflation-rate" style="display:none;">
+                Inflation rate
+                <input type="number" id="asset-inflation-rate" placeholder="%" />
+            </label>
 
             <div class="modal-actions">
                 <button id="delete-asset" class="danger hidden"><i class="fa fa-trash"></i></button>


### PR DESCRIPTION
## Summary
- support a new per-asset 'Subject to inflation?' toggle and rate field
- save inflation settings in localStorage
- update forecasting to apply inflation growth when enabled

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_688947289d74833087e7584f55d42a32