### PR TITLE
Add table year independence and row selection

### DIFF
--- a/app.js
+++ b/app.js
@@ -677,6 +677,23 @@ function highlightYearRows(){
     });
 }
 
+function updateAssetPercentages(values){
+    const spans = document.querySelectorAll('#asset-list .asset-percentage');
+    const total = values.reduce((s,v)=>s+v,0);
+    let idx = 0;
+    assets.forEach((asset,i)=>{
+        const span = spans[i];
+        if(!span) return;
+        if(asset.visible !== false){
+            const pct = total>0?((values[idx]/total)*100).toFixed(1):'0.0';
+            span.textContent = ` (${pct}%)`;
+            idx++;
+        } else {
+            span.textContent = ' (0.0%)';
+        }
+    });
+}
+
 function updatePieChart(year=null){
     const visible = assets.filter(a => a.visible !== false);
     const labels = visible.map(a=>a.name);
@@ -702,9 +719,7 @@ function updatePieChart(year=null){
         data: {labels, datasets:[{data, backgroundColor: colors}]},
         options: {plugins: {legend: {display: false}}}
     });
-}
-        options: {plugins: {legend: {display: false}}}
-    });
+    updateAssetPercentages(data);
 }
 
 function updateSankey(){

--- a/style.css
+++ b/style.css
@@ -226,7 +226,11 @@ h3 {
     background: #e0f2fe;
 }
 #year-table tr:hover td {
+    background: #f8fafc;
     cursor: pointer;
+}
+#year-table tr.selected:hover td {
+    background: #e0f2fe;
 }
 
 

--- a/style.css
+++ b/style.css
@@ -222,6 +222,12 @@ h3 {
     font-size: 0.875rem;
     letter-spacing: 0.05em;
 }
+#year-table tr.selected td {
+    background: #e0f2fe;
+}
+#year-table tr:hover td {
+    cursor: pointer;
+}
 
 
 #total-wealth {


### PR DESCRIPTION
## Summary
- decouple year table calculations from graph range
- allow selecting a year row to update the pie chart
- highlight selected table rows

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6889f12866988330a94e8d861e9da796