### PR TITLE
Add safe area padding for mobile layout

### DIFF
--- a/www/style.css
+++ b/www/style.css
@@ -7,6 +7,8 @@
     --accent: linear-gradient(120deg, #5eead4, #6366f1, #a855f7);
     --border: rgba(255,255,255,0.08);
     --shadow: 0 12px 40px rgba(3,7,18,0.35);
+    --safe-top: env(safe-area-inset-top, 0px);
+    --safe-bottom: env(safe-area-inset-bottom, 0px);
 }
 
 * { box-sizing: border-box; }
@@ -14,7 +16,7 @@
 body {
     font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     margin: 0;
-    padding: 0;
+    padding: var(--safe-top) 0 var(--safe-bottom);
     background: radial-gradient(circle at 20% 20%, rgba(94,234,212,0.08), transparent 30%),
                 radial-gradient(circle at 80% 0%, rgba(99,102,241,0.10), transparent 35%),
                 #0b1222;
@@ -34,12 +36,12 @@ body {
 
 .title-bar {
     position: sticky;
-    top: 0;
+    top: var(--safe-top);
     z-index: 20;
     backdrop-filter: blur(14px);
     background: rgba(11, 18, 34, 0.85);
     border-bottom: 1px solid var(--border);
-    padding: 1rem 1.25rem;
+    padding: calc(1rem + var(--safe-top) * 0.5) 1.25rem 1rem;
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -279,11 +281,11 @@ input:focus, select:focus { outline: 2px solid rgba(99,102,241,0.4); border-colo
 
 .tab-bar {
     position: fixed;
-    bottom: 0; left: 0; right: 0;
+    bottom: var(--safe-bottom); left: 0; right: 0;
     display: none;
     background: rgba(11,18,34,0.95);
     border-top: 1px solid var(--border);
-    padding: 0.35rem 0;
+    padding: 0.35rem 0 calc(0.35rem + var(--safe-bottom));
     z-index: 25;
     backdrop-filter: blur(10px);
 }
@@ -310,6 +312,7 @@ input:focus, select:focus { outline: 2px solid rgba(99,102,241,0.4); border-colo
     .chart-shell { min-height: 24vh; height: 320px; }
     /*.years-control { flex-direction: column; align-items: flex-start; }*/
     .tab-bar { display: flex; }
-    .fab { position: fixed; right: 16px; bottom: 90px; width: 58px; height: 58px; border-radius: 50%; padding: 0; display: grid; place-items: center; }
+    .layout { padding-bottom: calc(5rem + var(--safe-bottom)); }
+    .fab { position: fixed; right: 16px; bottom: calc(90px + var(--safe-bottom)); width: 58px; height: 58px; border-radius: 50%; padding: 0; display: grid; place-items: center; }
     .fab span { display: none; }
 }


### PR DESCRIPTION
## Summary
- add safe-area inset CSS variables to respect platform-specific top and bottom padding
- adjust body, title bar, tab bar, and floating action button spacing to avoid status bar and app switcher overlap
- add extra mobile layout padding to keep content clear of the tab bar

## Testing
- not run (not provided)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f2c02540083309a43626348b25b08)