### PR TITLE
Add mobile safe area padding

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -2,7 +2,10 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta
+        name="viewport"
+        content="viewport-fit=cover, width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no"
+    />
     <title>Cast - Wealth Forecast</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/www/style.css
+++ b/www/style.css
@@ -7,6 +7,19 @@
     --accent: linear-gradient(120deg, #5eead4, #6366f1, #a855f7);
     --border: rgba(255,255,255,0.08);
     --shadow: 0 12px 40px rgba(3,7,18,0.35);
+    --safe-top: 0px;
+    --safe-bottom: 0px;
+    --safe-left: 0px;
+    --safe-right: 0px;
+}
+
+@supports(padding: max(0px, env(safe-area-inset-top))) {
+    :root {
+        --safe-top: env(safe-area-inset-top);
+        --safe-bottom: env(safe-area-inset-bottom);
+        --safe-left: env(safe-area-inset-left);
+        --safe-right: env(safe-area-inset-right);
+    }
 }
 
 * { box-sizing: border-box; }
@@ -14,7 +27,7 @@
 body {
     font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     margin: 0;
-    padding: 0;
+    padding: var(--safe-top) var(--safe-right) calc(var(--safe-bottom) + 0.25rem) var(--safe-left);
     background: radial-gradient(circle at 20% 20%, rgba(94,234,212,0.08), transparent 30%),
                 radial-gradient(circle at 80% 0%, rgba(99,102,241,0.10), transparent 35%),
                 #0b1222;
@@ -34,12 +47,12 @@ body {
 
 .title-bar {
     position: sticky;
-    top: 0;
+    top: var(--safe-top);
     z-index: 20;
     backdrop-filter: blur(14px);
     background: rgba(11, 18, 34, 0.85);
     border-bottom: 1px solid var(--border);
-    padding: 1rem 1.25rem;
+    padding: calc(1rem + var(--safe-top) * 0.3) 1.25rem 1rem 1.25rem;
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -279,11 +292,11 @@ input:focus, select:focus { outline: 2px solid rgba(99,102,241,0.4); border-colo
 
 .tab-bar {
     position: fixed;
-    bottom: 0; left: 0; right: 0;
+    bottom: var(--safe-bottom); left: 0; right: 0;
     display: none;
     background: rgba(11,18,34,0.95);
     border-top: 1px solid var(--border);
-    padding: 0.35rem 0;
+    padding: 0.35rem 0 calc(0.35rem + var(--safe-bottom));
     z-index: 25;
     backdrop-filter: blur(10px);
 }
@@ -310,6 +323,6 @@ input:focus, select:focus { outline: 2px solid rgba(99,102,241,0.4); border-colo
     .chart-shell { min-height: 24vh; height: 320px; }
     /*.years-control { flex-direction: column; align-items: flex-start; }*/
     .tab-bar { display: flex; }
-    .fab { position: fixed; right: 16px; bottom: 90px; width: 58px; height: 58px; border-radius: 50%; padding: 0; display: grid; place-items: center; }
+    .fab { position: fixed; right: 16px; bottom: calc(90px + var(--safe-bottom)); width: 58px; height: 58px; border-radius: 50%; padding: 0; display: grid; place-items: center; }
     .fab span { display: none; }
 }

--- a/www/style.css
+++ b/www/style.css
@@ -15,7 +15,7 @@
 
 @supports(padding: max(0px, env(safe-area-inset-top))) {
     :root {
-        --safe-top: env(safe-area-inset-top);
+        --safe-top: max(12px, env(safe-area-inset-top));
         --safe-bottom: env(safe-area-inset-bottom);
         --safe-left: env(safe-area-inset-left);
         --safe-right: env(safe-area-inset-right);
@@ -27,13 +27,14 @@
 body {
     font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     margin: 0;
-    padding: var(--safe-top) var(--safe-right) calc(var(--safe-bottom) + 0.25rem) var(--safe-left);
+    /*padding: var(--safe-top) var(--safe-right) calc(var(--safe-bottom) + 0.25rem) var(--safe-left);*/
     background: radial-gradient(circle at 20% 20%, rgba(94,234,212,0.08), transparent 30%),
                 radial-gradient(circle at 80% 0%, rgba(99,102,241,0.10), transparent 35%),
                 #0b1222;
     color: var(--text);
     line-height: 1.6;
     min-height: 100vh;
+    margin: 0;
 }
 
 .bg-accent {
@@ -47,7 +48,7 @@ body {
 
 .title-bar {
     position: sticky;
-    top: var(--safe-top);
+    top: 0;
     z-index: 20;
     backdrop-filter: blur(14px);
     background: rgba(11, 18, 34, 0.85);
@@ -56,6 +57,7 @@ body {
     display: flex;
     align-items: center;
     justify-content: space-between;
+    padding-top: var(--safe-top);
 }
 
 .brand-mark { display: flex; align-items: center; gap: 0.75rem; }
@@ -294,11 +296,12 @@ input:focus, select:focus { outline: 2px solid rgba(99,102,241,0.4); border-colo
     position: fixed;
     bottom: var(--safe-bottom); left: 0; right: 0;
     display: none;
-    background: rgba(11,18,34,0.95);
+    background: rgba(11, 18, 34, 0.85);
     border-top: 1px solid var(--border);
     padding: 0.35rem 0 calc(0.35rem + var(--safe-bottom));
     z-index: 25;
     backdrop-filter: blur(10px);
+    bottom: 0;
 }
 .tab-bar button { background: none; border: none; flex: 1; padding: 0.35rem 0; font-size: 0.8rem; color: var(--muted); display: flex; flex-direction: column; gap: 0.2rem; align-items: center; }
 .tab-bar button.active { color: #fff; }


### PR DESCRIPTION
## Summary
- add CSS safe-area custom properties for platform-specific padding
- apply safe-area insets to body, header, tab bar, and floating action buttons for better mobile spacing

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f2c02540083309a43626348b25b08)